### PR TITLE
Django 2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,1 @@
-Django>=1.8,<2.0
+Django

--- a/src/mailrobot/models.py
+++ b/src/mailrobot/models.py
@@ -134,12 +134,12 @@ class Mail(AbstractNamedModel):
     }
 
     content = models.ForeignKey(MailBody, on_delete=models.CASCADE, related_name='mail')
-    signature = models.ForeignKey(Signature, related_name='mail', **KEYFIELD_DEFAULTS)
-    sender = models.ForeignKey(Address, related_name='sender', **KEYFIELD_DEFAULTS)
+    signature = models.ForeignKey(Signature, related_name='mail', on_delete=models.CASCADE, **KEYFIELD_DEFAULTS)
+    sender = models.ForeignKey(Address, related_name='sender', on_delete=models.CASCADE, **KEYFIELD_DEFAULTS)
     recipients = models.ManyToManyField(Address, related_name='recipients', **M2M_KEYFIELD_DEFAULTS)
     ccs = models.ManyToManyField(Address, related_name='cc', **M2M_KEYFIELD_DEFAULTS)
     bccs = models.ManyToManyField(Address, related_name='bcc', **M2M_KEYFIELD_DEFAULTS)
-    reply_to = models.ForeignKey(Address, related_name='reply_to', **KEYFIELD_DEFAULTS)
+    reply_to = models.ForeignKey(Address, related_name='reply_to', on_delete=models.CASCADE, **KEYFIELD_DEFAULTS)
 
     def clone(self):
         """Clone and return a Mail
@@ -148,9 +148,9 @@ class Mail(AbstractNamedModel):
         """
 
         newself = super(Mail, self).clone()
-        newself.recipients = self.recipients.all()
-        newself.ccs = self.ccs.all()
-        newself.bccs = self.bccs.all()
+        newself.recipients.set(self.recipients.all())
+        newself.ccs.set(self.ccs.all())
+        newself.bccs.set(self.bccs.all())
         return newself
 
     @property

--- a/src/mailrobot/tests.py
+++ b/src/mailrobot/tests.py
@@ -39,7 +39,7 @@ class CloneTest(TestCase):
     def test_mail_clone(self):
         model = self.mail
         model.sender = self.address
-        model.recipients = [self.address]
+        model.recipients.set([self.address])
         model.save()
         clone = model.clone()
         self.assertNotEqual(model, clone)


### PR DESCRIPTION
Makes mailrobot compatible with Django>=2.0.

Only change is to set `on_delete` to `CASCADE`, the default.

Also fixed tests, changed assignments to use `.set()` on many-to-many fields.