### PR TITLE
Support newer Pythons and Djangos, drop oldies

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -12,7 +12,7 @@ jobs:
 
     - uses: "actions/setup-python@v4"
       with:
-        python-version: "3.12"
+        python-version: "3.13"
 
     - name: "Find syntax errors"
       run: |
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: "actions/checkout@v4"

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Stores and sends canned email responses.
 Ever had to change the signature or add a recipient to N hardcoded emails
 spread all throughout your code? Hardcode no more! Use mailrobot instead.
 
-Depends on Django, with a version between 3.2 and 4.2, inclusive.
+Depends on Django, with a version between 3.2 and 6.0, inclusive.
 
 Installation
 ============

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,18 @@
 [tox]
 isolated_build = True
 envlist =
-    py{38,39,310,311,312}-django{32}
-    py{38,39}-django{42}
-    py{310,311,312}-django{42,50,52}
+    py{39,310,311,312}-django{32,42}
+    py{310,311,312,313,314}-django{52}
+    py{312,313,314}-django{60}
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
 [testenv]
 setenv =
@@ -21,8 +22,9 @@ commands =
 deps =
     django32: django>=3.2,<4
     django42: django>=4.2,<5
-    django50: django>=5.0,<5.1
-    django52: django>=5.2,<6
+    django52: django>=5.2,<6.0
+    django60: django>=6.0,<6.1
+    django61: django>=6.1,<6.2
 
 [flake8]
 exclude = .*,__pycache__,docs,migrations,*.py?,static,templates,*.csv,*.json,build,dist


### PR DESCRIPTION
* Add Python 3.13, Python 3.14. Django 6.0
* Drop Python 3.8, Django 5.0